### PR TITLE
速度重視のzip compression levelに設定

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -1287,7 +1287,7 @@ func createSubmissionsZip(zipFilePath string, classID string, submissions []Subm
 	}
 
 	// -i 'tmpDir/*': 空zipを許す
-	return exec.Command("zip", "-j", "-r", zipFilePath, tmpDir, "-i", tmpDir+"*").Run()
+	return exec.Command("zip", "-1", "-j", "-r", zipFilePath, tmpDir, "-i", tmpDir+"*").Run()
 }
 
 // ---------- Announcement API ----------


### PR DESCRIPTION
refs https://github.com/oystersjp/isucon-practice-20211016/issues/1

appサーバのCPUが割と早いタイミングで張り付いているので少しでもCPU使用率が下がるようにzipファイル作る時に速度重視の設定にしてCPU負荷を下げる。